### PR TITLE
Fix off-by-one issues in MatchLenWord

### DIFF
--- a/src/lzsa2.s
+++ b/src/lzsa2.s
@@ -306,6 +306,8 @@ DecodeMatchLen:             ; Match offset in A
     inc <LZSA2_source
     lda [<LZSA2_source]
     inc <LZSA2_source
+    inc <LZSA2_source
+    dec
     bra @CopyMatch
 
 @MatchLenByte:              ; Match length: Byte + nibble value + 2


### PR DESCRIPTION
In @MatchLenWord there's two issues I've found when testing this.
One is that the LZSA2_Source is only incremented by one byte after the 16-bit read which misaligns it for further reads.
The other issue is that the length isn't decremented by one after reading it which cases the MVN operation to run over by one byte.